### PR TITLE
configurable autoupdate

### DIFF
--- a/pgpsync/buttons.py
+++ b/pgpsync/buttons.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import platform
 from PyQt5 import QtCore, QtWidgets, QtGui
 
 class Buttons(QtWidgets.QVBoxLayout):
     sync_now_signal = QtCore.pyqtSignal(bool)
     quit_signal = QtCore.pyqtSignal()
+    autoupdate_signal = QtCore.pyqtSignal(bool)
 
     def __init__(self, settings):
         super(Buttons, self).__init__()
@@ -25,6 +27,14 @@ class Buttons(QtWidgets.QVBoxLayout):
             self.run_automatically_checkbox.setCheckState(QtCore.Qt.Unchecked)
         self.run_automatically_checkbox.stateChanged.connect(self.run_automatically_changed)
 
+        # Check for automatic updates
+        self.run_autoupdate_checkbox = QtWidgets.QCheckBox("Check for updates automatically")
+        if self.settings.run_autoupdate:
+            self.run_autoupdate_checkbox.setCheckState(QtCore.Qt.Checked)
+        else:
+            self.run_autoupdate_checkbox.setCheckState(QtCore.Qt.Unchecked)
+        self.run_autoupdate_checkbox.stateChanged.connect(self.run_autoupdate_changed)
+
         # Next sync label
         self.sync_label = QtWidgets.QLabel()
         self.update_sync_label(None)
@@ -36,6 +46,8 @@ class Buttons(QtWidgets.QVBoxLayout):
         self.addLayout(buttons_layout)
         self.addWidget(self.sync_label)
         self.addWidget(self.run_automatically_checkbox)
+        if platform.system() != 'Linux':
+            self.addWidget(self.run_autoupdate_checkbox)
 
     def sync_now(self):
         self.sync_now_signal.emit(True)
@@ -52,3 +64,8 @@ class Buttons(QtWidgets.QVBoxLayout):
     def run_automatically_changed(self, state):
         self.settings.run_automatically = (state == QtCore.Qt.Checked)
         self.settings.save()
+
+    def run_autoupdate_changed(self, state):
+        self.settings.run_autoupdate = (state == QtCore.Qt.Checked)
+        self.settings.save()
+        self.autoupdate_signal.emit((state == QtCore.Qt.Checked))

--- a/pgpsync/pgpsync.py
+++ b/pgpsync/pgpsync.py
@@ -87,6 +87,7 @@ class PGPSync(QtWidgets.QMainWindow):
         # Buttons
         self.buttons = Buttons(self.settings)
         self.buttons.sync_now_signal.connect(self.sync_all_endpoints)
+        self.buttons.autoupdate_signal.connect(self.configure_autoupdate)
         self.buttons.quit_signal.connect(self.app.quit)
         self.sync_msg = None
 
@@ -119,7 +120,7 @@ class PGPSync(QtWidgets.QMainWindow):
         self.refresh_timer.start(60000) # 1 minute
 
         # Timer to check for automatic updates
-        if self.system != 'Linux':
+        if self.system != 'Linux' and self.settings.run_autoupdate:
             self.check_for_updates() # Check first on start up
             self.updater_timer = QtCore.QTimer()
             self.updater_timer.timeout.connect(self.check_for_updates)
@@ -399,6 +400,21 @@ class PGPSync(QtWidgets.QMainWindow):
 
     def force_check_for_updates(self):
         self.check_for_updates(True)
+
+    def configure_autoupdate(self, state):
+        if state:
+            try:
+                if self.updater_timer:
+                    self.force_check_for_updates()
+                    self.updater_timer.start(86400000)
+            except:
+                self.check_for_updates() # Check first on start up
+                self.updater_timer = QtCore.QTimer()
+                self.updater_timer.timeout.connect(self.check_for_updates)
+                self.updater_timer.start(86400000) # 24 hours
+        else:
+            if self.updater_timer:
+                self.updater_timer.stop()
 
 def main():
     app = Application()

--- a/pgpsync/settings.py
+++ b/pgpsync/settings.py
@@ -16,19 +16,32 @@ class Settings(object):
     def load(self):
         if os.path.isfile(self.settings_path):
             self.settings = pickle.load(open(self.settings_path, 'rb'))
-            self.endpoints = self.settings['endpoints']
-            self.run_automatically = self.settings['run_automatically']
+            if 'endpoints' in self.settings:
+                self.endpoints = self.settings['endpoints']
+            else:
+                self.endpoints = []
+            if 'run_automatically' in self.settings:
+                self.run_automatically = self.settings['run_automatically']
+            else:
+                self.run_automatically = True
+            if 'run_autoupdate' in self.settings:
+                self.run_autoupdate = self.settings['run_autoupdate']
+            else:
+                self.run_autoupdate = True
         else:
             # default settings
             self.endpoints = []
             self.run_automatically = True
+            self.run_autoupdate = True
 
         self.configure_run_automatically()
 
     def save(self):
         self.settings = {
             'endpoints': self.endpoints,
-            'run_automatically': self.run_automatically
+            'run_automatically': self.run_automatically,
+            'run_autoupdate': self.run_autoupdate
+
         }
         pickle.dump(self.settings, open(self.settings_path, 'wb'))
 


### PR DESCRIPTION
Adds a checkbox option to autoupdate or not (OS X only)

![screen shot 2016-06-28 at 2 54 39 pm](https://cloud.githubusercontent.com/assets/1214373/16428516/43e95ba8-3d40-11e6-9ff0-fced026b9475.png)

Resolves #25 and implements changes to `settings.load` to resolve #24 
