### PR TITLE
Last updated fixes

### DIFF
--- a/pgpsync/endpoint.py
+++ b/pgpsync/endpoint.py
@@ -32,6 +32,8 @@ class Endpoint(object):
         self.proxy_host = b'127.0.0.1'
         self.proxy_port = b'9050'
         self.last_checked = None
+        self.last_synced = None
+        self.last_failed = None
         self.error = None
         self.warning = None
 

--- a/pgpsync/endpoint_selection.py
+++ b/pgpsync/endpoint_selection.py
@@ -69,7 +69,10 @@ class EndpointWidget(QtWidgets.QWidget):
 
         # Last updated
         if self.e.last_checked:
-            diff = datetime.datetime.now() - self.e.last_checked
+            if self.e.error:
+                diff = datetime.datetime.now() - self.e.last_failed
+            else:
+                diff = datetime.datetime.now() - self.e.last_synced
             s = diff.seconds
             hours = s // 3600
             s = s - (hours * 3600)
@@ -84,7 +87,11 @@ class EndpointWidget(QtWidgets.QWidget):
                 last_checked = '{} seconds ago'.format(seconds)
         else:
             last_checked = 'never'
-        self.last_checked_label.setText('Last updated: {}'.format(last_checked))
+
+        if self.e.error:
+            self.last_checked_label.setText('Last attempted: {}'.format(last_checked))
+        else:
+            self.last_checked_label.setText('Last synced: {}'.format(last_checked))
 
         # Warning and error
         if self.e.warning:

--- a/pgpsync/pgpsync.py
+++ b/pgpsync/pgpsync.py
@@ -297,6 +297,7 @@ class PGPSync(QtWidgets.QMainWindow):
             warning = ', '.join(warnings)
 
         e.last_checked = datetime.datetime.now()
+        e.last_synced = datetime.datetime.now()
         e.warning = warning
         e.error = None
 
@@ -306,6 +307,7 @@ class PGPSync(QtWidgets.QMainWindow):
     def refresher_error(self, e, err, reset_last_checked=True):
         if reset_last_checked:
             e.last_checked = datetime.datetime.now()
+        e.last_failed = datetime.datetime.now()
         e.warning = None
         e.error = err
 


### PR DESCRIPTION
Resolves #19 by explicitly saving `last_synced` and `last_failed` timestamps. The messaging to the user also switches based on the latest outcome.

Successful sync:
![screen shot 2016-06-30 at 4 24 26 pm](https://cloud.githubusercontent.com/assets/1214373/16503059/318fef9e-3edf-11e6-8ece-d791df97e584.png)

Failed attempt:
![screen shot 2016-06-30 at 4 24 41 pm](https://cloud.githubusercontent.com/assets/1214373/16503065/38f19512-3edf-11e6-8e91-22062a21b421.png)
