### PR TITLE
Circleci tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   pre:
     - sudo apt-get update ; sudo apt-get install gnupg2
   override:
-    - pip install -r ./install/requirements.txt
+    - pip install -r ./install/requirements-circleci.txt
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,4 @@ dependencies:
 
 test:
   override:
-    - nosetests
+    - nosetests --nocapture

--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,4 @@ dependencies:
 
 test:
   override:
-    - nosetests --nocapture
+    - nosetests

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 
 dependencies:
   pre:
-    - sudo apt-get update ; sudo apt-get install gnupg2
+    - sudo apt-get update ; sudo apt-get install gnupg2 python3-pyqt5 tor
   override:
     - pip install -r ./install/requirements-circleci.txt
 

--- a/gpgsync/gnupg.py
+++ b/gpgsync/gnupg.py
@@ -113,10 +113,10 @@ class GnuPG(object):
         args = ['--recv-keys', fp]
         out,err = self._gpg(args)
 
-        if b"No keyserver available" in err:
+        if b"No keyserver available" in err or b"gpgkeys: HTTP fetch error" in out:
             raise InvalidKeyserver(keyserver)
 
-        if b"not found on keyserver" in err or b"keyserver receive failed: No data" in err:
+        if b"not found on keyserver" in err or b"keyserver receive failed: No data" in err or b"no valid OpenPGP data found" in err:
             raise NotFoundOnKeyserver(fp)
 
         if b"keyserver receive failed" in err:

--- a/install/requirements-circleci.txt
+++ b/install/requirements-circleci.txt
@@ -1,9 +1,6 @@
 packaging==16.8
-PyInstaller==3.2.1
 pyparsing==2.2.0
-PyQt5==5.7.1
 PySocks==1.6.6
 python-dateutil==2.6.0
 requests==2.13.0
-sip==4.19
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-cffi==1.6.0
-cryptography==1.4
-idna==2.1
-pyasn1==0.1.9
-pycparser==2.14
-PyInstaller==3.3.dev0+d25657e
-PySocks==1.5.7
-requests==2.10.0
-six==1.10.0

--- a/test/gnupg_test.py
+++ b/test/gnupg_test.py
@@ -17,12 +17,12 @@ def test_gpg_recv_key():
 
 @raises(InvalidKeyserver)
 def test_gpg_recv_key_invalid_keyserver():
-    gpg = GnuPG(debug=True)
+    gpg = GnuPG()
     gpg.recv_key(b'hkp://fakekeyserver', test_key_fp, False, None, None)
 
 @raises(NotFoundOnKeyserver)
 def test_gpg_recv_key_not_found_on_keyserver():
-    gpg = GnuPG(debug=True)
+    gpg = GnuPG()
     gpg.recv_key(b'hkp://keys.gnupg.net', b'0000000000000000000000000000000000000000', False, None, None)
 
 @raises(InvalidFingerprint)

--- a/test/gnupg_test.py
+++ b/test/gnupg_test.py
@@ -17,12 +17,12 @@ def test_gpg_recv_key():
 
 @raises(InvalidKeyserver)
 def test_gpg_recv_key_invalid_keyserver():
-    gpg = GnuPG()
+    gpg = GnuPG(debug=True)
     gpg.recv_key(b'hkp://fakekeyserver', test_key_fp, False, None, None)
 
 @raises(NotFoundOnKeyserver)
 def test_gpg_recv_key_not_found_on_keyserver():
-    gpg = GnuPG()
+    gpg = GnuPG(debug=True)
     gpg.recv_key(b'hkp://keys.gnupg.net', b'0000000000000000000000000000000000000000', False, None, None)
 
 @raises(InvalidFingerprint)


### PR DESCRIPTION
Fixing the circleci tests. This also includes a bugfix -- the `GnuPG` class wasn't throwing the correct exceptions on `fetch_key` if the version of gpg is 2.0.x instead of 2.1.x.