### PR TITLE
Valid signature, but signed with wrong signing key

### DIFF
--- a/gpgsync/gnupg.py
+++ b/gpgsync/gnupg.py
@@ -268,7 +268,9 @@ class GnuPG(object):
         lines = err.split(b'\n')
         for i in range(len(lines)):
             if lines[i].startswith(b'gpg: Signature made'):
-                if lines[i+1].split()[-1] not in self.list_all_keyids(fp):
+                signing_fp = lines[i+1].split()[-1]
+                signing_keyid = self.fp_to_long_keyid(fp)
+                if signing_keyid not in self.list_all_keyids(fp):
                     raise SignedWithWrongKey
                 break
 
@@ -285,6 +287,11 @@ class GnuPG(object):
             raise NotFoundInKeyring
 
         return re.findall(b'0x[A-F\d]{16}', out)
+
+    def fp_to_long_keyid(self, fp):
+        if re.match(b'0x[A-F\d]{16}', fp):
+            return fp
+        return b'0x' + fp[-16:]
 
     def import_to_default_homedir(self, fp):
         self.log("import_to_default_homedir: fp={}".format(fp))

--- a/gpgsync/gnupg.py
+++ b/gpgsync/gnupg.py
@@ -269,7 +269,7 @@ class GnuPG(object):
         for i in range(len(lines)):
             if lines[i].startswith(b'gpg: Signature made'):
                 signing_fp = lines[i+1].split()[-1]
-                signing_keyid = self.fp_to_long_keyid(fp)
+                signing_keyid = self.fp_to_long_keyid(signing_fp)
                 if signing_keyid not in self.list_all_keyids(fp):
                     raise SignedWithWrongKey
                 break


### PR DESCRIPTION
It appears that newer versions of gpg2 display the full fingerprint in the `--verify` output, but older versions of gpg2 display the long keyid (`0x` and the final 16 hex chars of the fingerprint). GPG Sync was only checking for the long keyid.

This patch ensures that fingerprints are verified with the correct key no matter which format the signing key fingerprint is displayed in, the full fingerprint or the long keyid.

Resolves #111 