### PR TITLE
Adds docker build commands for linux packages

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -68,6 +68,21 @@ Make and install a .rpm:
 sudo dnf install dist/gpgsync_*.rpm
 ```
 
+## Alternatively utilize Docker to build the relevant debian/rpm
+
+There are `make` commands to build for the latest stable of debian (`stretch`)
+and fedora (`27`):
+
+```sh
+make build-fedora27-rpm
+```
+
+or
+
+```sh
+build-debianstretch-deb
+```
+
 ## Run the tests
 
 From the `gpgsync` folder run:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+VERSION=`cat share/version`
+
+.PHONY: build-fedora27-rpm
+build-fedora27-rpm:
+	@docker run -it -v "${PWD}:/mnt" -w /mnt fedora:27 sh -c "dnf install -y rpm-build python3-qt5 python3-requests python3-nose python3-packaging python3-dateutil gnupg2 && ./install/build_rpm.sh"
+
+.PHONY: build-debianstretch-deb
+build-debianstretch-deb:
+	@docker run -it -v "${PWD}:/mnt" -w /mnt debian:stretch sh -c "apt-get update && apt-get install -y python3-pyqt5 python3-nose python3-stdeb python3-requests python3-socks python3-packaging python3-dateutil gnupg2 python-all && ./install/build_deb.sh"


### PR DESCRIPTION
Fixes #116

Adds two docker build commands into a `Makefile` and updates the documentation a bit to reference these make cmds.