### PR TITLE
Rename "endpoints" to "keylists" in UI

### DIFF
--- a/gpgsync/endpoint.py
+++ b/gpgsync/endpoint.py
@@ -259,7 +259,7 @@ class Verifier(QtCore.QThread):
         self.q.add_message(message, step)
 
     def run(self):
-        print("Verifying endpoint with authority key {}".format(self.fingerprint.decode()))
+        print("Verifying keylist with authority key {}".format(self.fingerprint.decode()))
 
         # Make an endpoint
         e = Endpoint(self.c)
@@ -419,7 +419,7 @@ class Refresher(QtCore.QThread):
         self.c.log("Refresher", func, message)
 
     def run(self):
-        print("Refreshing endpoint with authority key {}".format(self.e.fingerprint.decode()))
+        print("Refreshing keylist with authority key {}".format(self.e.fingerprint.decode()))
 
         self.q.add_message(RefresherMessageQueue.STATUS_STARTING)
 

--- a/gpgsync/endpoint_dialog.py
+++ b/gpgsync/endpoint_dialog.py
@@ -35,11 +35,11 @@ class EndpointDialog(QtWidgets.QDialog):
         # If endpoint == None, this is an add endpoint dialog. Otherwise, this
         # is an edit endpoint dialog
         if endpoint:
-            self.setWindowTitle('Edit Endpoint')
+            self.setWindowTitle('Edit Keylist')
             self.endpoint = endpoint
             self.new_endpoint = False
         else:
-            self.setWindowTitle('Add Endpoint')
+            self.setWindowTitle('Add Keylist')
             self.endpoint = Endpoint(self.c)
             self.new_endpoint = True
         self.setWindowIcon(self.c.icon)
@@ -197,11 +197,11 @@ class VerifierDialog(QtWidgets.QDialog):
         super(VerifierDialog, self).__init__()
         self.c = common
 
-        self.setWindowTitle('Verifying Endpoint')
+        self.setWindowTitle('Verifying Keylist')
         self.setWindowIcon(self.c.icon)
 
         # Label
-        self.label = QtWidgets.QLabel("Verifying endpoint")
+        self.label = QtWidgets.QLabel("Verifying keylist")
 
         # Progress bar
         self.progress_bar = QtWidgets.QProgressBar()

--- a/gpgsync/gpgsync.py
+++ b/gpgsync/gpgsync.py
@@ -190,10 +190,10 @@ class GPGSync(QtWidgets.QMainWindow):
 
         # Add button
         if len(self.c.settings.endpoints) == 0:
-            self.add_button.setText("Add First GPG Sync Endpoint")
+            self.add_button.setText("Add First GPG Sync Keylist")
             self.add_button.setStyleSheet(self.c.css['GPGSync add_button_first'])
         else:
-            self.add_button.setText("Add Endpoint")
+            self.add_button.setText("Add Keylist")
             self.add_button.setStyleSheet(self.c.css['GPGSync add_button'])
 
         # Update the endpoint list

--- a/gpgsync/settings_dialog.py
+++ b/gpgsync/settings_dialog.py
@@ -64,7 +64,7 @@ class SettingsLayout(QtWidgets.QVBoxLayout):
 
         # Update interval
         update_interval_hlayout = QtWidgets.QHBoxLayout()
-        update_interval_label = QtWidgets.QLabel('Time between endpoint syncs (in hours)')
+        update_interval_label = QtWidgets.QLabel('Time between keylist syncs (in hours)')
         self.update_interval_edit = QtWidgets.QLineEdit()
         self.update_interval_edit.setText(self.settings.update_interval_hours.decode())
         update_interval_hlayout.addWidget(update_interval_label)

--- a/gpgsync/systray.py
+++ b/gpgsync/systray.py
@@ -44,7 +44,7 @@ class SysTray(QtWidgets.QSystemTrayIcon):
         self.version_info.setEnabled(False)
         self.show_act = self.menu.addAction(self.show_text)
         self.show_act.triggered.connect(self.clicked_show)
-        self.refresh_act = self.menu.addAction('Sync endpoints')
+        self.refresh_act = self.menu.addAction('Sync keylists')
         self.refresh_act.triggered.connect(self.clicked_refresh)
         if platform.system() != 'Linux':
             self.update_act = self.menu.addAction('Check for updates')


### PR DESCRIPTION
To be consistent with the work-in-progress [OpenPGPSync-RFC](https://github.com/firstlookmedia/openpgpsync-rfc), this pull request changes all mentions of `endpoints` with `keylists`.

This change affects the user interface only, and does not affect any internal naming conventions.

If this pull request is merged, it might be worthwhile to add a note in the wiki to say that `keylists` are synonymous with `endpoints` to prevent confusion.

(This is the first part of a series of pull requests I hope to submit that will bring GPGSync in full compliance with the new spec.)