### PR TITLE
Use default keyserver if not keyserver is specified

### DIFF
--- a/gpgsync/gnupg.py
+++ b/gpgsync/gnupg.py
@@ -30,6 +30,10 @@ class InvalidFingerprint(Exception):
     pass
 
 
+class InvalidKeyserver(Exception):
+    pass
+
+
 class KeyserverError(Exception):
     pass
 
@@ -93,7 +97,10 @@ class GnuPG(object):
     def __del__(self):
         # Delete the temporary homedir
         shutil.rmtree(self.homedir, ignore_errors=True)
-        self.c.log("GnuPG", "__del__", "deleted homedir: {}".format(self.homedir))
+
+        # Commenting out log, because when running tests __del__ seems to run without
+        # capturing output
+        #self.c.log("GnuPG", "__del__", "deleted homedir: {}".format(self.homedir))
 
     def is_gpg_available(self):
         if self.system == 'Windows':
@@ -135,6 +142,9 @@ class GnuPG(object):
 
         args = ['--recv-keys', fp]
         out,err = self._gpg(args)
+
+        if b"could not parse keyserver URL" in err:
+            raise InvalidKeyserver(keyserver)
 
         if b"No keyserver available" in err or b"gpg: keyserver communications error: General error" in err or b"gpgkeys: HTTP fetch error" in out:
             raise KeyserverError(keyserver)

--- a/gpgsync/keylist.py
+++ b/gpgsync/keylist.py
@@ -352,6 +352,8 @@ class Keylist(object):
             return self.result_object('error', 'The authority key is expired', data={"reset_last_checked": True})
         except KeyserverError:
             return self.result_object('error', 'Error connecting to keyserver', data={"reset_last_checked": False})
+        except InvalidKeyserver:
+            return self.result_object('error', 'Invalid keyserver', data={"reset_last_checked": False})
 
     def refresh_keylist_uri(self):
         """
@@ -439,6 +441,8 @@ class Keylist(object):
                 self.c.gpg.recv_key(self.keyserver, fingerprint, self.use_proxy, self.proxy_host, self.proxy_port)
             except KeyserverError:
                 return self.result_object('error', 'Keyserver error')
+            except InvalidKeyserver:
+                return self.result_object('error', 'Invalid keyserver')
             except NotFoundOnKeyserver:
                 notfound_fingerprints.append(fingerprint)
 

--- a/gpgsync/keylist.py
+++ b/gpgsync/keylist.py
@@ -438,7 +438,7 @@ class Keylist(object):
         for fingerprint in fingerprints_to_fetch:
             try:
                 self.c.log('Keylist', 'refresh_fetch_fingerprints', 'Fetching public key {} {}'.format(self.c.fp_to_keyid(fingerprint).decode(), self.c.gpg.get_uid(fingerprint)))
-                self.c.gpg.recv_key(self.keyserver, fingerprint, self.use_proxy, self.proxy_host, self.proxy_port)
+                self.c.gpg.recv_key(self.get_keyserver(), fingerprint, self.use_proxy, self.proxy_host, self.proxy_port)
             except KeyserverError:
                 return self.result_object('error', 'Keyserver error')
             except InvalidKeyserver:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,7 +20,7 @@ qt_app = QtWidgets.QApplication(sys.argv)
 def common():
     appdata_path = tempfile.mkdtemp()
 
-    common = Common(debug=False)
+    common = Common(debug=True)
     common.gpg = GnuPG(common, appdata_path=appdata_path)
     return common
 

--- a/test/gnupg_test.py
+++ b/test/gnupg_test.py
@@ -3,9 +3,9 @@ import os
 import subprocess
 import pytest
 
-from gpgsync.gnupg import GnuPG, InvalidFingerprint, KeyserverError, \
-    NotFoundOnKeyserver, NotFoundInKeyring, RevokedKey, ExpiredKey, \
-    VerificationError, BadSignature, SignedWithWrongKey
+from gpgsync.gnupg import GnuPG, InvalidFingerprint, InvalidKeyserver, \
+    KeyserverError, NotFoundOnKeyserver, NotFoundInKeyring, RevokedKey, \
+    ExpiredKey, VerificationError, BadSignature, SignedWithWrongKey
 
 # Test fingerprint
 test_key_fp = b'3B72C32B49CBB5BBDD57440E1D07D43448FB8382'
@@ -28,6 +28,11 @@ def test_gpg_is_available(common):
 def test_gpg_recv_key(common):
     common.gpg.recv_key(b'hkp://keyserver.ubuntu.com', test_key_fp, False, None, None)
     assert common.gpg.get_uid(test_key_fp) == 'GPG Sync Unit Test Key (not secure in any way)'
+
+
+def test_gpg_recv_key_uses_default_keyserver(common):
+    with pytest.raises(InvalidKeyserver):
+        common.gpg.recv_key(None, test_key_fp, False, None, None)
 
 
 def test_gpg_recv_key_invalid_keyserver(common):


### PR DESCRIPTION
Now when there's an issue with the keyserver URI, it throws an exception. And when fetching keys, it always gets the keyserver using the `Keylist.get_keyserver()` method to ensure not sending a blank keyserver to `GnuPG.recv_key()`.

Resolves #150.