### PR TITLE
Rename --debug to --verbose and -v

### DIFF
--- a/gpgsync/__init__.py
+++ b/gpgsync/__init__.py
@@ -37,17 +37,17 @@ def main():
 
     # Parse arguments
     parser = argparse.ArgumentParser(formatter_class=lambda prog: argparse.HelpFormatter(prog,max_help_position=48))
-    parser.add_argument('--debug', action='store_true', dest='debug', help="Log debug output to stdout")
+    parser.add_argument('--verbose', '-v', action='store_true', dest='verbose', help="Show lots of output, useful for debugging")
     parser.add_argument('--sync', action='store_true', dest='sync', help="Sync all keylists without loading the GUI")
     parser.add_argument('--force', action='store_true', dest='force', help="If syncing without the GUI, force sync again even if it has synced recently")
     args = parser.parse_args()
 
-    debug = args.debug
+    verbose = args.verbose
     sync = args.sync
     force = args.force
 
     # Create the common object
-    common = Common(debug)
+    common = Common(verbose)
 
     # If we only want to sync keylists
     if sync:

--- a/gpgsync/common.py
+++ b/gpgsync/common.py
@@ -37,8 +37,8 @@ class Common(object):
     """
     The Common class is a singleton of shared functionality throughout the app
     """
-    def __init__(self, debug):
-        self.debug = debug
+    def __init__(self, verbose):
+        self.verbose = verbose
 
         # Define the OS
         self.os = platform.system()
@@ -54,7 +54,7 @@ class Common(object):
         self.gpg = GnuPG(self, appdata_path=self.settings.get_appdata_path())
 
     def log(self, module, func, msg=''):
-        if self.debug:
+        if self.verbose:
             final_msg = "[{}] {}".format(module, func)
             if msg:
                 final_msg = "{}: {}".format(final_msg, msg)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,7 +20,7 @@ qt_app = QtWidgets.QApplication(sys.argv)
 def common():
     appdata_path = tempfile.mkdtemp()
 
-    common = Common(debug=True)
+    common = Common(verbose=True)
     common.gpg = GnuPG(common, appdata_path=appdata_path)
     return common
 


### PR DESCRIPTION
All starting in debug mode, `--debug`, actually does is display verbose output. So this renames the flag to `--verbose`, or just `-v`.