### PR TITLE
Support keys.openpgp.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ internet standard draft.
 
 ### Important note about keyservers
 
-By default, GPG Sync downloads PGP public keys from the [keys.openpgp.org](https://keys.openpgp.org/about), a modern keyserver that is resistent against abuse. (The old SKS keyserver pool is vulnerable to [certificate flooding](https://dkg.fifthhorseman.net/blog/openpgp-certificate-flooding.html) attacks, and it's based on unmaintained software that will likely never get fixed.)
+By default, GPG Sync downloads PGP public keys from the [keys.openpgp.org](https://keys.openpgp.org/about), a modern abuse-resistent keyserver. (The old SKS keyserver pool is vulnerable to [certificate flooding](https://dkg.fifthhorseman.net/blog/openpgp-certificate-flooding.html) attacks, and it's based on unmaintained software that will likely never get fixed.)
 
 For this reason, **it's important that your authority key, as well as every key on your keylist, has a user ID that contains an email address** and that **all users must opt-in to allowing their email addresses** on this keyserver. You can opt-in by uploading your public key [here](https://keys.openpgp.org/upload), requesting to verify each email address on it, and then clicking the links you receive in those verification emails.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ and then you forget about it. GPG Sync takes care of everything else.
 GPG Sync complies with the in-progress [Distributing OpenPGP Keys with Signed Keylist Subscriptions](https://datatracker.ietf.org/doc/draft-mccain-keylist/)
 internet standard draft.
 
+### Important note about keyservers
+
+By default, GPG Sync downloads PGP public keys from the [keys.openpgp.org](https://keys.openpgp.org/about), a modern keyserver that is resistent against abuse. (The old SKS keyserver pool is vulnerable to [certificate flooding](https://dkg.fifthhorseman.net/blog/openpgp-certificate-flooding.html) attacks, and it's based on unmaintained software that will likely never get fixed.)
+
+For this reason, **it's important that your authority key, as well as every key on your keylist, has a user ID that contains an email address** and that **all users must opt-in to allowing their email addresses** on this keyserver. You can opt-in by uploading your public key [here](https://keys.openpgp.org/upload), requesting to verify each email address on it, and then clicking the links you receive in those verification emails.
+
+If a member of your organization doesn't opt-in to allowing their email addresses on this keyserver, then when subscribers of your keylist refresh it, the public key that GPG Sync will import won't contain the information necessary to be able to send that member an encrypted email. GPG Sync still supports the legacy, vulnerable SKS keyserver network; this can be enabled in the advanced settings of each keylist.
+
 ## Learn More
 
 To learn how GPG Sync works and how to use it, check out the [Wiki](https://github.com/firstlookmedia/gpgsync/wiki).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ internet standard draft.
 
 ### Important note about keyservers
 
-By default, GPG Sync downloads PGP public keys from the [keys.openpgp.org](https://keys.openpgp.org/about), a modern abuse-resistent keyserver. (The old SKS keyserver pool is vulnerable to [certificate flooding](https://dkg.fifthhorseman.net/blog/openpgp-certificate-flooding.html) attacks, and it's based on unmaintained software that will likely never get fixed.)
+By default, GPG Sync downloads PGP public keys from [keys.openpgp.org](https://keys.openpgp.org/about), a modern abuse-resistent keyserver. (The old SKS keyserver pool is vulnerable to [certificate flooding](https://dkg.fifthhorseman.net/blog/openpgp-certificate-flooding.html) attacks, and it's based on unmaintained software that will likely never get fixed.)
 
 For this reason, **it's important that your authority key, as well as every key on your keylist, has a user ID that contains an email address** and that **all users must opt-in to allowing their email addresses** on this keyserver. You can opt-in by uploading your public key [here](https://keys.openpgp.org/upload), requesting to verify each email address on it, and then clicking the links you receive in those verification emails.
 

--- a/gpgsync/gui/keylist_dialog.py
+++ b/gpgsync/gui/keylist_dialog.py
@@ -66,7 +66,7 @@ class KeylistDialog(QtWidgets.QDialog):
 
         # SOCKS5 proxy settings
         self.use_proxy = QtWidgets.QCheckBox()
-        self.use_proxy.setText("Load URL through SOCKS5 proxy (e.g. Tor)")
+        self.use_proxy.setText("Load URL through Tor (Tor daemon not included)")
         self.use_proxy.setCheckState(QtCore.Qt.Unchecked)
         proxy_host_label = QtWidgets.QLabel('Host')
         self.proxy_host_edit = QtWidgets.QLineEdit()
@@ -80,7 +80,7 @@ class KeylistDialog(QtWidgets.QDialog):
         proxy_vlayout = QtWidgets.QVBoxLayout()
         proxy_vlayout.addWidget(self.use_proxy)
         proxy_vlayout.addLayout(proxy_hlayout)
-        proxy_group = QtWidgets.QGroupBox("Proxy Configuration")
+        proxy_group = QtWidgets.QGroupBox("Tor Configuration")
         proxy_group.setLayout(proxy_vlayout)
 
         # Advanced settings button

--- a/gpgsync/gui/keylist_dialog.py
+++ b/gpgsync/gui/keylist_dialog.py
@@ -54,8 +54,14 @@ class KeylistDialog(QtWidgets.QDialog):
         self.url_edit = QtWidgets.QLineEdit()
         self.url_edit.setPlaceholderText("https://")
 
+        # Use modern keyserver
+        self.use_modern_keyserver = QtWidgets.QCheckBox()
+        self.use_modern_keyserver.setText("Use modern keyserver: keys.openpgp.org")
+        self.use_modern_keyserver.setCheckState(QtCore.Qt.Checked)
+        self.use_modern_keyserver.stateChanged.connect(self.toggle_use_modern_keyserver)
+
         # Keyserver
-        keyserver_label = QtWidgets.QLabel("Key server")
+        self.keyserver_label = QtWidgets.QLabel("Key server")
         self.keyserver_edit = QtWidgets.QLineEdit()
 
         # SOCKS5 proxy settings
@@ -85,7 +91,9 @@ class KeylistDialog(QtWidgets.QDialog):
 
         # Advanced settings group
         advanced_layout = QtWidgets.QVBoxLayout()
-        advanced_layout.addWidget(keyserver_label)
+        advanced_layout.addWidget(self.use_modern_keyserver)
+        advanced_layout.addSpacing(10)
+        advanced_layout.addWidget(self.keyserver_label)
         advanced_layout.addWidget(self.keyserver_edit)
         advanced_layout.addWidget(proxy_group)
         self.advanced_group = QtWidgets.QGroupBox("Advanced Settings")
@@ -115,6 +123,10 @@ class KeylistDialog(QtWidgets.QDialog):
         # Populate the widgets with keylist data
         self.fingerprint_edit.setText(self.keylist.fingerprint.decode())
         self.url_edit.setText(self.keylist.url.decode())
+        if self.keylist.use_modern_keyserver:
+            self.use_modern_keyserver.setCheckState(QtCore.Qt.Checked)
+        else:
+            self.use_modern_keyserver.setCheckState(QtCore.Qt.Unchecked)
         if self.keylist.keyserver:
             self.keyserver_edit.setText(self.keylist.keyserver.decode())
         if self.keylist.use_proxy:
@@ -127,6 +139,7 @@ class KeylistDialog(QtWidgets.QDialog):
         # Initially update the widgets
         self.advanced_group.show()
         self.toggle_advanced() # Hide advanced settings to start with
+        self.toggle_use_modern_keyserver() # Show/hide keyserver settings to start with
 
     def toggle_advanced(self):
         if self.advanced_group.isHidden():
@@ -137,18 +150,27 @@ class KeylistDialog(QtWidgets.QDialog):
             self.advanced_group.hide()
 
         self.adjustSize()
+    
+    def toggle_use_modern_keyserver(self):
+        if self.use_modern_keyserver.isChecked():
+            self.keyserver_label.hide()
+            self.keyserver_edit.hide()
+        else:
+            self.keyserver_label.show()
+            self.keyserver_edit.show()
 
     def save_clicked(self):
         # Grab the values
         fingerprint = self.fingerprint_edit.text().encode()
         url = self.url_edit.text().encode()
+        use_modern_keyserver = self.use_modern_keyserver.isChecked()
         keyserver = self.keyserver_edit.text().encode()
         use_proxy = self.use_proxy.isChecked()
         proxy_host = self.proxy_host_edit.text().encode()
         proxy_port = self.proxy_port_edit.text().encode()
 
         # Open the validator dialog
-        d = ValidatorDialog(self.c, fingerprint, url, keyserver, use_proxy, proxy_host, proxy_port)
+        d = ValidatorDialog(self.c, fingerprint, url, use_modern_keyserver, keyserver, use_proxy, proxy_host, proxy_port)
         d.success.connect(self.validated)
         d.exec_()
 
@@ -160,6 +182,7 @@ class KeylistDialog(QtWidgets.QDialog):
         self.keylist.fingerprint = self.fingerprint_edit.text().encode()
         self.keylist.url = self.url_edit.text().encode()
         self.keylist.sig_url = self.keylist.url + b'.sig'
+        self.keylist.use_modern_keyserver = self.use_modern_keyserver.isChecked()
         self.keylist.keyserver = self.keyserver_edit.text().encode()
         self.keylist.use_proxy = self.use_proxy.isChecked()
         self.keylist.proxy_host = self.proxy_host_edit.text().encode()
@@ -180,7 +203,7 @@ class KeylistDialog(QtWidgets.QDialog):
 class ValidatorDialog(QtWidgets.QDialog):
     success = QtCore.pyqtSignal()
 
-    def __init__(self, common, fingerprint, url, keyserver, use_proxy, proxy_host, proxy_port):
+    def __init__(self, common, fingerprint, url, use_modern_keyserver, keyserver, use_proxy, proxy_host, proxy_port):
         super(ValidatorDialog, self).__init__()
         self.c = common
 
@@ -196,7 +219,7 @@ class ValidatorDialog(QtWidgets.QDialog):
         self.setLayout(layout)
 
         # Start the validator
-        self.validator = AuthorityKeyValidatorThread(self.c, fingerprint, url, keyserver, use_proxy, proxy_host, proxy_port)
+        self.validator = AuthorityKeyValidatorThread(self.c, fingerprint, url, use_modern_keyserver, keyserver, use_proxy, proxy_host, proxy_port)
         self.validator.alert_error.connect(self.validator_alert_error)
         self.validator.success.connect(self.validator_success)
         self.validator.finished.connect(self.validator_finished)

--- a/gpgsync/gui/threads.py
+++ b/gpgsync/gui/threads.py
@@ -33,7 +33,7 @@ class AuthorityKeyValidatorThread(QtCore.QThread):
     alert_error = QtCore.pyqtSignal(str, str)
     success = QtCore.pyqtSignal()
 
-    def __init__(self, common, fingerprint, url, keyserver, use_proxy, proxy_host, proxy_port):
+    def __init__(self, common, fingerprint, url, use_modern_keyserver, keyserver, use_proxy, proxy_host, proxy_port):
         super(AuthorityKeyValidatorThread, self).__init__()
         self.c = common
 
@@ -41,6 +41,7 @@ class AuthorityKeyValidatorThread(QtCore.QThread):
         self.keylist = Keylist(self.c)
         self.keylist.fingerprint = fingerprint
         self.keylist.url = url
+        self.keylist.use_modern_keyserver = use_modern_keyserver
         self.keylist.keyserver = keyserver
         self.keylist.use_proxy = use_proxy
         self.keylist.proxy_host = proxy_host

--- a/gpgsync/keylist.py
+++ b/gpgsync/keylist.py
@@ -344,7 +344,7 @@ class Keylist(object):
             self.c.log('Keylist', 'validate_authority_key', 'keyserver={}'.format(keyserver))
 
             # Retreive the authority key from the keyserver
-            self.c.gpg.recv_key(keyserver, self.fingerprint, self.use_proxy, self.proxy_host, self.proxy_port)
+            self.c.gpg.recv_key(self.use_modern_keyserver, keyserver, self.fingerprint, self.use_proxy, self.proxy_host, self.proxy_port)
 
             # Test the key for issues
             self.c.gpg.test_key(self.fingerprint)
@@ -451,7 +451,7 @@ class Keylist(object):
         for fingerprint in fingerprints_to_fetch:
             try:
                 self.c.log('Keylist', 'refresh_fetch_fingerprints', 'Fetching public key {} {}'.format(self.c.fp_to_keyid(fingerprint).decode(), self.c.gpg.get_uid(fingerprint)))
-                self.c.gpg.recv_key(self.get_keyserver(), fingerprint, self.use_proxy, self.proxy_host, self.proxy_port)
+                self.c.gpg.recv_key(self.use_modern_keyserver, self.get_keyserver(), fingerprint, self.use_proxy, self.proxy_host, self.proxy_port)
             except KeyserverError:
                 return self.result_object('error', 'Keyserver error')
             except InvalidKeyserver:

--- a/gpgsync/keylist.py
+++ b/gpgsync/keylist.py
@@ -94,6 +94,7 @@ class Keylist(object):
 
         self.fingerprint = b''
         self.url = b''
+        self.use_modern_keyserver = True
         self.keyserver = None
         self.use_proxy = False
         self.proxy_host = b'127.0.0.1'
@@ -118,26 +119,38 @@ class Keylist(object):
         """
         Acts as a secondary constructor to load an keylist from settings
         """
-        self.fingerprint = str.encode(e['fingerprint'])
-        self.url = str.encode(e['url'])
-        self.keyserver = str.encode(e['keyserver'])
-        self.use_proxy = e['use_proxy']
-        self.proxy_host = str.encode(e['proxy_host'])
-        self.proxy_port = str.encode(e['proxy_port'])
-        self.last_checked = (date_parser.parse(e['last_checked']) if e['last_checked'] is not None else None)
-        self.last_synced = (date_parser.parse(e['last_synced']) if e['last_synced'] is not None else None)
-        self.last_failed = (date_parser.parse(e['last_failed']) if e['last_failed'] is not None else None)
-        self.error = e['error']
-        self.warning = e['warning']
+        if 'fingerprint' in e:
+            self.fingerprint = str.encode(e['fingerprint'])
+        if 'url' in e:
+            self.url = str.encode(e['url'])
+        if 'use_modern_keyserver' in e:
+            self.use_modern_keyserver = e['use_modern_keyserver']
+        if 'keyserver' in e:
+            self.keyserver = str.encode(e['keyserver'])
+        if 'use_proxy' in e:
+            self.use_proxy = e['use_proxy']
+        if 'proxy_host' in e:
+            self.proxy_host = str.encode(e['proxy_host'])
+        if 'proxy_port' in e:
+            self.proxy_port = str.encode(e['proxy_port'])
+        if 'last_checked' in e:
+            self.last_checked = (date_parser.parse(e['last_checked']) if e['last_checked'] is not None else None)
+        if 'last_synced' in e:
+            self.last_synced = (date_parser.parse(e['last_synced']) if e['last_synced'] is not None else None)
+        if 'last_failed' in e:
+            self.last_failed = (date_parser.parse(e['last_failed']) if e['last_failed'] is not None else None)
+        if 'error' in e:
+            self.error = e['error']
+        if 'warning' in e:
+            self.warning = e['warning']
         return self
 
     def serialize(self):
         tmp = {}
 
         # Serialize only the attributes that should persist
-        keys = ['fingerprint', 'url', 'keyserver', 'use_proxy',  'proxy_host',
-                'proxy_port', 'last_checked', 'last_synced', 'last_failed',
-                'error', 'warning']
+        keys = ['fingerprint', 'url', 'use_modern_keylist', 'keyserver', 'use_proxy', 'proxy_host',
+                'proxy_port', 'last_checked', 'last_synced', 'last_failed', 'error', 'warning']
         for k, v in self.__dict__.items():
             if k in keys:
                 if isinstance(v, bytes):

--- a/test/gnupg_test.py
+++ b/test/gnupg_test.py
@@ -26,24 +26,23 @@ def test_gpg_is_available(common):
 
 
 def test_gpg_recv_key(common):
-    common.gpg.recv_key(b'hkp://keyserver.ubuntu.com', test_key_fp, False, None, None)
+    common.gpg.recv_key(False, b'hkp://keyserver.ubuntu.com', test_key_fp, False, None, None)
     assert common.gpg.get_uid(test_key_fp) == 'GPG Sync Unit Test Key (not secure in any way)'
 
 
 def test_gpg_recv_key_uses_default_keyserver(common):
     with pytest.raises(InvalidKeyserver):
-        common.gpg.recv_key(None, test_key_fp, False, None, None)
+        common.gpg.recv_key(False, None, test_key_fp, False, None, None)
 
 
 def test_gpg_recv_key_invalid_keyserver(common):
     with pytest.raises(KeyserverError):
-        common.gpg.recv_key(b'hkp://fakekeyserver', test_key_fp, False, None, None)
+        common.gpg.recv_key(False, b'hkp://fakekeyserver', test_key_fp, False, None, None)
 
 
 def test_gpg_recv_key_not_found_on_keyserver(common):
     with pytest.raises(NotFoundOnKeyserver):
-        common.gpg.recv_key(b'hkp://keyserver.ubuntu.com', b'0000000000000000000000000000000000000000', False, None, None)
-
+        common.gpg.recv_key(False, b'hkp://keyserver.ubuntu.com', b'0000000000000000000000000000000000000000', False, None, None)
 
 def test_gpg_test_key_invalid_fingerprint(common):
     with pytest.raises(InvalidFingerprint):


### PR DESCRIPTION
This PR resolves #171.

- It uses keys.openpgp.org as the default keyserver -- you have to uncheck a box in the keylist settings to use a legacy keyserver
- Using a proxy is renamed to use Tor, and if this is checked it uses the onion service for keys.openpgp.org
- When using a modern keyserver, it downloads keys over the VKS interface (instead of subprocessing gpg for each key) and then imports them all at once at the end, which makes refreshing a keylist waaaay quicker and more efficient
- It updates the readme to include the requirement that everyone on the keylist opt-in to allowing their email addresses on keys.openpgp.org

<img width="543" alt="Screen Shot 2019-07-31 at 4 18 32 PM" src="https://user-images.githubusercontent.com/156128/62254753-3e74c700-b3af-11e9-9753-d006f152d23a.png">
